### PR TITLE
debug build directory and release build directory

### DIFF
--- a/Project.xml
+++ b/Project.xml
@@ -29,7 +29,9 @@
 
 	<!-- _____________________________ Path Settings ____________________________ -->
 
-	<set name="BUILD_DIR" value="export" />
+	<set name="BUILD_DIR" value="export/debug" if="debug"/>
+	<set name="BUILD_DIR" value="export/release" unless="debug"/>
+
 	<source path="source" />
 	<assets path="assets" />
 


### PR DESCRIPTION
When compiling release builds and debug builds you are going to need to seperate one from another, especally when the debug builds have assets that don't make it into the final release.